### PR TITLE
Adopt new name 'PivotPro Release Dashboard'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ An Azure DevOps extension that shows a Deployment Summary page within the Azure 
 
 See the extension in the Visual Studio Marketplace [here](https://marketplace.visualstudio.com/items?itemName=SixPivot.sixpivot-release-dashboard)
 
-The extension adds a 'Deployment Dashboard' item to the Pipelines menu
+The extension adds a 'PivotPro Release Dashboard' item to the Pipelines menu
 
-![Menu showing Deployment Dashboard menu item](extension/img/menu-screenshot.png)
+![Menu showing PivotPro Release Dashboard menu item](extension/img/menu-screenshot.png)
 
-Selecting this loads the Deployment Dashboard page (this may take a while depending on how many environments and deployments you have)
+Selecting this loads the PivotPro Release Dashboard page (this may take a while depending on how many environments and deployments you have)
 
-![Example deployment dashboard screenshot](extension/img/dashboard-screenshot.png)
+![Example PivotPro Release Dashboard screenshot](extension/img/dashboard-screenshot.png)
 
 You can configure the extension via the Settings page, including reordering the environment. The default order is alphabetical, which can result in 'prod' appearing before 'test'!
 

--- a/extension/DEV_GUIDE.md
+++ b/extension/DEV_GUIDE.md
@@ -1,4 +1,4 @@
-# Deployment Dashboard
+# PivotPro Release Dashboard
 
 Local development and debugging of the extension (except for the most simple changes) will generally require that you have access to an Azure DevOps organisation that you can publish your own 'dev' copy of the extension, which alters the baseUri to point to your local machine.
 
@@ -35,9 +35,9 @@ Local development and debugging of the extension (except for the most simple cha
 
 1. `npm run start:dev`
 1. Go to <localhost:3000> in your browser. You should get an untrusted certificate error page. Select **Advanced** and then select **Accept the Risk and Continue**.
-1. In Azure DevOps, open a project and go to the **Azure Pipelines** section and click on the **Deployment Dashboard** item that links to a page ending in `sixpivot-release-dashboard-dev.deployment-dashboard` (Note the `-dev` in the name!)
+1. In Azure DevOps, open a project and go to the **Azure Pipelines** section and click on the **PivotPro Release Dashboard** item that links to a page ending in `sixpivot-release-dashboard-dev.deployment-dashboard` (Note the `-dev` in the name!)
 
-    ![Dev deployment dashboard](../assets/azure-pipelines-menu-dev-extension.png)
+    ![Dev PivotPro Release Dashboard](../assets/azure-pipelines-menu-dev-extension.png)
 
 1. You can now make local changes to the extension code. As this extension is pointing back to <https://localhost:3000> you should be ready to make changes to your code and see it hot-reload.
 

--- a/extension/OVERVIEW.md
+++ b/extension/OVERVIEW.md
@@ -1,4 +1,4 @@
-# Deployment Dashboard for Pipelines
+# PivotPro Release Dashboard for Pipelines
 
 This dashboard lets you easily see an overview of all your recent pipeline deployments including:
 

--- a/extension/src/dashboard/DashboardContent.test.tsx
+++ b/extension/src/dashboard/DashboardContent.test.tsx
@@ -11,7 +11,7 @@ test('Render and check layout', async () => {
 
     await screen.findByRole('heading')
 
-    expect(screen.getByRole('heading')).toHaveTextContent('Deployment Dashboard')
+    expect(screen.getByRole('heading')).toHaveTextContent('PivotPro Release Dashboard')
 
     await screen.findByRole('grid')
     expect(screen.getByRole('grid')).not.toBeUndefined()

--- a/extension/src/dashboard/DashboardContent.tsx
+++ b/extension/src/dashboard/DashboardContent.tsx
@@ -51,7 +51,7 @@ export const DashboardContent = (props: DashboardContentProps) => {
         {
             iconProps: { iconName: 'Settings' },
             id: 'deployment-dashboard-settings',
-            tooltipProps: { text: 'Navigate to deployment dashboard settings' },
+            tooltipProps: { text: 'Navigate to PivotPro Release Dashboard settings' },
             isPrimary: true,
             important: true,
             href: projectInfo?.settingsUri,
@@ -70,7 +70,7 @@ export const DashboardContent = (props: DashboardContentProps) => {
                 <HeaderTitleArea>
                     <HeaderTitleRow>
                         <HeaderTitle ariaLevel={3} className="text-ellipsis" titleSize={TitleSize.Large}>
-                            Deployment Dashboard
+                            PivotPro Release Dashboard
                         </HeaderTitle>
                     </HeaderTitleRow>
                     <HeaderDescription className="flex-row flex-center justify-space-between">

--- a/extension/src/settings/SettingsContent.tsx
+++ b/extension/src/settings/SettingsContent.tsx
@@ -40,7 +40,7 @@ export const SettingsContent = (props: ISettingsContentProps) => {
         {
             iconProps: { iconName: 'ViewDashboard' },
             id: 'deployment-dashboard',
-            tooltipProps: { text: 'Navigate to deployment dashboard' },
+            tooltipProps: { text: 'Navigate to PivotPro Release Dashboard' },
             isPrimary: true,
             important: true,
             href: state.projectInfo?.deploymentDashboardUri,
@@ -88,10 +88,10 @@ export const SettingsContent = (props: ISettingsContentProps) => {
                 <HeaderTitleArea>
                     <HeaderTitleRow>
                         <HeaderTitle ariaLevel={3} className="text-ellipsis" titleSize={TitleSize.Large}>
-                            Deployment Dashboard Settings
+                            PivotPro Release Dashboard Settings
                         </HeaderTitle>
                     </HeaderTitleRow>
-                    <HeaderDescription>Customise deployment dashboard</HeaderDescription>
+                    <HeaderDescription>Customise PivotPro Release Dashboard</HeaderDescription>
                 </HeaderTitleArea>
                 <HeaderCommandBar items={pageHeaderCommandBarItems} />
             </CustomHeader>

--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "sixpivot-release-dashboard",
     "publisher": "sixpivot",
     "version": "1.0.128",
-    "name": "Release Dashboard",
+    "name": "PivotPro Release Dashboard",
     "description": "A dashboard to view a summary of all deployments",
     "demands": ["api-version/3.0"],
     "categories": ["Azure Pipelines"],
@@ -45,16 +45,16 @@
     "scopes": ["vso.build", "vso.release", "vso.environment_manage"],
     "repository": {
         "type": "git",
-        "uri": "https://github.com/SixPivot/AzureDevopsDeploymentDashboard"
+        "uri": "https://github.com/SixPivot/PivotProReleaseDashboard"
     },
     "contributions": [
         {
             "id": "deployment-dashboard",
             "type": "ms.vss-web.hub",
-            "description": "Deployment dashboard page",
+            "description": "PivotPro Release Dashboard page",
             "targets": ["ms.vss-build-web.build-release-hub-group"],
             "properties": {
-                "name": "Deployment Dashboard",
+                "name": "PivotPro Release Dashboard",
                 "uri": "dist/dashboard/dashboard.html",
                 "order": 1,
                 "icon": {
@@ -66,10 +66,10 @@
         {
             "id": "deployment-dashboard-settings",
             "type": "ms.vss-web.hub",
-            "description": "Deployment dashboard settings",
+            "description": "PivotPro Release Dashboard settings",
             "targets": ["ms.vss-web.project-admin-hub-group"],
             "properties": {
-                "name": "Deployment dashboard settings",
+                "name": "PivotPro Release Dashboard settings",
                 "uri": "dist/settings/settings.html",
                 "order": 1,
                 "icon": {


### PR DESCRIPTION
- Note, this is just a branding update. There is no change to the extension being free or open source