### PR TITLE
Defer build name lookup

### DIFF
--- a/extension/src/__mocks__/azure-devops-extension-api.js
+++ b/extension/src/__mocks__/azure-devops-extension-api.js
@@ -1,0 +1,4 @@
+// Mock for azure-devops-extension-api
+module.exports = {
+    getClient: jest.fn(() => ({})),
+}

--- a/extension/src/__mocks__/azure-devops-extension-api/Build.js
+++ b/extension/src/__mocks__/azure-devops-extension-api/Build.js
@@ -1,0 +1,4 @@
+// Mock for azure-devops-extension-api/Build
+module.exports = {
+    BuildRestClient: jest.fn(),
+}

--- a/extension/src/__mocks__/azure-devops-extension-api/Pipelines/PipelinesClient.js
+++ b/extension/src/__mocks__/azure-devops-extension-api/Pipelines/PipelinesClient.js
@@ -1,0 +1,4 @@
+// Mock for azure-devops-extension-api/Pipelines/PipelinesClient
+module.exports = {
+    PipelinesRestClient: jest.fn(),
+}

--- a/extension/src/__mocks__/azure-devops-extension-api/TaskAgent.js
+++ b/extension/src/__mocks__/azure-devops-extension-api/TaskAgent.js
@@ -1,0 +1,4 @@
+// Mock for azure-devops-extension-api/TaskAgent
+module.exports = {
+    TaskAgentRestClient: jest.fn(),
+}

--- a/extension/src/dashboard/DashboardContent.tsx
+++ b/extension/src/dashboard/DashboardContent.tsx
@@ -102,7 +102,7 @@ export const DashboardContent = (props: DashboardContentProps) => {
                             </div>
                         </div>
                     ) : viewType === ViewType.List ? (
-                        <ListViewDeploymentsTable environments={environments} pipelines={pipelines} />
+                        <ListViewDeploymentsTable environments={environments} pipelines={pipelines} projectName={projectInfo?.name} />
                     ) : (
                         <TreeViewDeploymentsTable environments={environments} pipelines={pipelines} />
                     )}

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -39,6 +39,7 @@ export interface IDeploymentInstance {
     folder?: string
     finishTime: Date
     uri: string
+    ownerId?: number // Added for deferred build name lookup
 }
 
 /**


### PR DESCRIPTION
- Only get build name(s) after page has first rendered. This should avoid making initial page load time take too long
